### PR TITLE
Configuration and compilation errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 
 # configuration #####
-set(CUDA_TOOLKIT_ROOT_DIR "/usr/local/cuda/" CACHE STRING "CUDA path")
+#set(CUDA_TOOLKIT_ROOT_DIR "/usr/local/cuda/" CACHE STRING "CUDA path")
 
 # choose CUDA, OPENCL
 IF(NOT AURA_BACKEND)
@@ -14,10 +14,15 @@ INCLUDE(cmake/functions.cmake)
 
 
 # find Boost libraries #####
-SET(Boost_USE_STATIC_LIBS ON)
-SET(BOOST_ROOT "/usr/local/boost")
-SET(Boost_ADDITIONAL_VERSIONS "1.54" "1.54.0" "1.48" "1.48.0" "1.51" "1.51.0")
-FIND_PACKAGE(Boost 1.45.0 COMPONENTS system thread unit_test_framework)
+OPTION(BOOST_TEST_DYN_LINK "Link tests against dynamic version of boost unittest library" ON)
+IF (WIN32)
+    SET(Boost_USE_STATIC_LIBS ON)
+ELSE ()
+  IF (BOOST_TEST_DYN_LINK)
+    ADD_DEFINITIONS(-DBOOST_TEST_DYN_LINK)
+  ENDIF ()
+ENDIF()
+FIND_PACKAGE(Boost COMPONENTS system thread unit_test_framework)
 
 # find CUDA libraries #####
 FIND_PACKAGE(CUDA)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -5,8 +5,10 @@ AURA_ADD_TARGET(bench.backend backend.cpp backend.cu backend.cl
 AURA_ADD_TARGET(bench.micro micro.cpp micro.cl micro.cu 
   ${AURA_BACKEND_LIBRARIES})
 
-AURA_ADD_TARGET(bench.fft fft.cpp ${AURA_BACKEND_LIBRARIES}
-  ${AURA_FFT_LIBRARIES} pthread)
+IF(NOT ${AURA_FFT_LIBRARIES} STREQUAL "")
+  AURA_ADD_TARGET(bench.fft fft.cpp ${AURA_BACKEND_LIBRARIES}
+    ${AURA_FFT_LIBRARIES} pthread)
+ENDIF()
 
 AURA_ADD_TARGET(bench.peak peak.cpp peak.cc 
   ${AURA_BACKEND_LIBRARIES})

--- a/include/aura/backend/opencl/args.hpp
+++ b/include/aura/backend/opencl/args.hpp
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <utility>
+#include <cstring>
 
 #include <aura/detail/svec.hpp>
 


### PR DESCRIPTION
This PR fixes cmake configuration and a compile error that I got on my system (Gentoo Linux, g++ 4.8.2).

Changes to CmakeLists.txt remove dependence on hard-coded paths to CUDA and Boost and restrict static linking to Boost libraries to Win32 systems.

Change to args.hpp includes `<cstring>` header where `memcpy()` is declared.

I am not sure these will work universally though, so please take it with a grain of salt.
