### PR TITLE
Memory leak in OpenCL kernels (and nicer print_module_build_log)

### DIFF
--- a/include/boost/aura/backend/opencl/device.hpp
+++ b/include/boost/aura/backend/opencl/device.hpp
@@ -148,9 +148,6 @@ public:
 							kernel_string, *this,
 							build_options)));
 			it = it2.first;	
-			if (debug) {
-				print_module_build_log(it2.first->second, *this);
-			}
 		}
 		
 		return create_kernel(it->second, kernel_name);

--- a/include/boost/aura/backend/opencl/kernel.hpp
+++ b/include/boost/aura/backend/opencl/kernel.hpp
@@ -53,7 +53,9 @@ inline void print_module_build_log(module & m, const device & d) {
     log_size, log, NULL);
 
   // Print the log
-  printf("%s\n", log);
+  if (strncmp("\n\0", log, 2) != 0) {
+	printf("%s\n", log);
+  }
   free(log);
 }
 


### PR DESCRIPTION
Hi Sebastian,

I am pretty sure I found a leak of device memory in aura with OpenCL.

If you look at [this example program](https://gist.github.com/hcmh/dff401be0dde3f327e16#file-opencl_kernel_leak)
all device memory should be free after the test() function finished. If you look at the consumed device memory with something like `nvidia-smi` while the application is still running, you can see that there is still memory used. This memory is only released when the entire application finished.

This is normally not visible, but when using `matlab`s mex-interface, this used memory would increase with each use, eventually crashing with an OpenCL out of memory error.

The problem seems to be related to the way kernels are used in aura with OpenCL: Kernel objects are created but never released. Even the destruction of their parent `cl_program`s is not enough to free them. That's why I implemented a path to keep track of the kernels and release them whenever we destroy the `cl_context`.

And at this point in writing the pull request I realized that my code is crap, since the vector will grow by one each time we call a kernel, even if the kernel already exists in this form in the vector (and a vector is the wrong data type anyway).
Well, that means I'll need to change it, probably to a similar map as is already used by the modules, or even just add the kernel to its corresponding module. But before I do that, I'd like to know even you would even accept a patch that solves this problem in this way (and if you can even reproduce this problem and it actually IS a  true leak and not sill my fault).

There is an unrelated patch for `print_module_build_log` in this same pull request, since I couldn't figure out how to separate them without creating new branches. 
