### PR TITLE
module type rewrite

### DIFF
--- a/experiment/CMakeLists.txt
+++ b/experiment/CMakeLists.txt
@@ -8,6 +8,8 @@ IF(${AURA_BACKEND} STREQUAL OPENCL)
     ${Boost_THREAD_LIBRARY} pthread rt)
   AURA_ADD_TARGET(exp.oclpinning oclpinning.cpp 
     ${AURA_BACKEND_LIBRARIES})
+  AURA_ADD_TARGET(exp.opencl_kernel_leak opencl_kernel_leak.cpp
+    ${AURA_BACKEND_LIBRARIES})
   # TODO: this does not work on NVIDIA currently
   # reason: NVIDIA supports OCL 1.0, we need 1.1/1.2
   #AURA_ADD_TARGET(exp.ocltexture ocltexture.cpp

--- a/experiment/opencl_kernel_leak.cpp
+++ b/experiment/opencl_kernel_leak.cpp
@@ -1,0 +1,48 @@
+
+#include <complex>
+#include <vector>
+#include <iostream>
+#include <stdio.h>
+#include <boost/aura/backend.hpp>
+#include <boost/aura/copy.hpp>
+#include <boost/aura/device_array.hpp>
+
+using namespace boost::aura;
+
+const char* empty_kernel_str = R"kernel_str(
+	
+	#include <boost/aura/backend.hpp>
+
+	AURA_KERNEL void empty_kernel(AURA_GLOBAL cfloat* src)
+	{
+	}
+		
+		)kernel_str";
+
+void test(void) 
+{
+	initialize();
+	device d(2);  
+	feed f(d);
+	auto empty_kernel = d.load_from_string(
+			"empty_kernel",
+			empty_kernel_str,
+			AURA_BACKEND_COMPILE_FLAGS, true);
+	std::vector<std::complex<float>> v(1);
+	device_array<std::complex<float>> dv(1, d);
+	copy(v, dv, f);
+	invoke(empty_kernel, bounds(100000), args(dv.begin_ptr()), f);
+	wait_for(f);
+}
+
+
+int main(void)
+{
+    test();
+    // at this point, everything should have been freed correctly.
+    // Checking the memory usage, though, reveals a leak
+    std::cin.ignore();
+}
+
+
+

--- a/include/boost/aura/backend/opencl/device.hpp
+++ b/include/boost/aura/backend/opencl/device.hpp
@@ -148,9 +148,6 @@ public:
 							kernel_string, *this,
 							build_options)));
 			it = it2.first;	
-			if (debug) {
-				print_module_build_log(it2.first->second, *this);
-			}
 		}
 		
 		return create_kernel(it->second, kernel_name);

--- a/include/boost/aura/backend/opencl/device.hpp
+++ b/include/boost/aura/backend/opencl/device.hpp
@@ -18,29 +18,25 @@
 #include <boost/aura/backend/opencl/context.hpp>
 #include <boost/aura/misc/deprecate.hpp>
 #include <boost/aura/device_lock.hpp>
-
+#include <boost/aura/backend/opencl/module.hpp>
 namespace boost {
 namespace aura {
 namespace backend_detail {
 namespace opencl {
 
 class device;
-
-/// module handle
-typedef cl_program module;
+class module;
 
 /// kernel handle
 typedef cl_kernel kernel;
 
-module create_module_from_string(const char * str, device & d,
-		const char * build_options);
+
 
 module create_module_from_file(const char * filename, device & d,
 		const char * build_options);
 
-kernel create_kernel(module m, const char * kernel_name);
+kernel create_kernel(module& m, const char * kernel_name);
 
-void print_module_build_log(module & m, const device & d);
 
 /**
  * device class
@@ -119,20 +115,12 @@ public:
 	{
 		auto it = modules_.find(file_name);
 		if (modules_.end() == it) {
-			std::ifstream in(file_name, std::ios::in);
-			AURA_CHECK_ERROR(in);
-			in.seekg(0, std::ios::end);
-			std::string fcontent;
-			fcontent.resize(in.tellg());
-			in.seekg(0, std::ios::beg);
-			in.read(&fcontent[0], fcontent.size());
-			in.close();
 			auto it2 = modules_.insert(std::make_pair(file_name,
-				create_module_from_string(fcontent.c_str(),
+				create_module_from_file(file_name,
 						*this, build_options)));
 			it = it2.first;
 		}
-		return create_kernel(it->second, kernel_name);
+		return it->second.get_kernel(kernel_name);
 	}
 
 	/// load a kernel from a string 
@@ -143,14 +131,13 @@ public:
 		auto it = modules_.find(kernel_string);
 		if (modules_.end() == it) {
 			auto it2 = modules_.insert(
-					std::make_pair(kernel_string, 
-						create_module_from_string(
-							kernel_string, *this,
-							build_options)));
+					std::move(std::make_pair(kernel_string,
+						std::move(module(kernel_string, *this,
+							build_options)))));
 			it = it2.first;	
 		}
 		
-		return create_kernel(it->second, kernel_name);
+		return it->second.get_kernel(kernel_name);
 	}
 
 	/**
@@ -371,6 +358,20 @@ inline device create_device_exclusive()
 	throw "no device available!";
 }
 
+
+inline kernel create_kernel(module& m, const char * kernel_name)
+{
+	return m.get_kernel(kernel_name);
+}
+
+inline const cl_device_id & get_backend_device(const device & d)
+{
+	return d.get_backend_device();
+}
+inline const cl_context & get_backend_context(const device & d)
+{
+	return d.get_backend_context();
+}
 
 } // opencl 
 } // backend_detail

--- a/include/boost/aura/backend/opencl/kernel.hpp
+++ b/include/boost/aura/backend/opencl/kernel.hpp
@@ -1,6 +1,6 @@
 #ifndef AURA_BACKEND_OPENCL_KERNEL_HPP
 #define AURA_BACKEND_OPENCL_KERNEL_HPP
-
+#if 0
 #ifdef __APPLE__
 	#include "OpenCL/opencl.h"
 #else
@@ -8,13 +8,15 @@
 #endif
 #include <boost/aura/backend/opencl/call.hpp>
 #include <boost/aura/backend/opencl/device.hpp>
-#include <boost/aura/backend/opencl/module.hpp>
+
 
 namespace boost
 {
 namespace aura {
 namespace backend_detail {
 namespace opencl {
+
+class module;
 
 /// kernel handle
 typedef cl_kernel kernel;
@@ -32,37 +34,12 @@ inline kernel create_kernel(module m, const char * kernel_name) {
   return k;
 }
 
-/**
- * @brief print the module build log
- *
- * @param m the module that is built
- * @param d the device the module is built for
- */
-inline void print_module_build_log(module & m, const device & d) {
-  // from http://stackoverflow.com/a/9467325/244786
-  // Determine the size of the log
-  std::size_t log_size;
-  clGetProgramBuildInfo(m, d.get_backend_device(), 
-    CL_PROGRAM_BUILD_LOG, 0, NULL, &log_size);
 
-  // Allocate memory for the log
-  char *log = (char *) malloc(log_size);
-
-  // Get the log
-  clGetProgramBuildInfo(m, d.get_backend_device(), CL_PROGRAM_BUILD_LOG, 
-    log_size, log, NULL);
-
-  // Print the log
-  if (strncmp("\n\0", log, 2) != 0) {
-	printf("%s\n", log);
-  }
-  free(log);
-}
 
 } // opencl
 } // backend_detail
 } // aura
 } // boost
-
+#endif // 0
 #endif // AURA_BACKEND_OPENCL_KERNEL_HPP
 

--- a/include/boost/aura/backend/opencl/kernel.hpp
+++ b/include/boost/aura/backend/opencl/kernel.hpp
@@ -53,7 +53,9 @@ inline void print_module_build_log(module & m, const device & d) {
     log_size, log, NULL);
 
   // Print the log
-  printf("%s\n", log);
+  if (strncmp("\n\0", log, 2) != 0) {
+	printf("%s\n", log);
+  }
   free(log);
 }
 

--- a/include/boost/aura/backend/opencl/module.hpp
+++ b/include/boost/aura/backend/opencl/module.hpp
@@ -4,40 +4,150 @@
 #include <fstream>
 #include <string>
 #include <cstring>
-#include <boost/aura/backend/shared/call.hpp>
-#include <boost/aura/backend/opencl/call.hpp>
-#include <boost/aura/backend/opencl/device.hpp>
+#include <boost/move/move.hpp>
+// #include <boost/aura/backend/shared/call.hpp>
+// #include <boost/aura/backend/opencl/call.hpp>
+// #include <boost/aura/backend/opencl/device.hpp>
+// #include <boost/aura/backend/opencl/kernel.hpp>
 
 namespace boost {
 namespace aura {
 namespace backend_detail {
 namespace opencl {
 
-/// module handle
-typedef cl_program module;
+class module;
+class device;
+const cl_context & get_backend_context(const device & d);
+const cl_device_id & get_backend_device(const device & d);
+typedef cl_kernel kernel;
 
-/**
- * @brief build a kernel module from a source string 
- *
- * @ param str string containing kernel source code
- * @param device device the module is built for
- * @param build_options options for the compiler (optional)
- *
- * @return module reference to compiled module
- */
-inline module create_module_from_string(const char * str, device & d,
-		const char * build_options=NULL) {
-	int errorcode = 0;
-	std::size_t len = strlen(str);
-	module m = clCreateProgramWithSource(d.get_backend_context(), 1,
-			&str, &len, &errorcode);
-	AURA_OPENCL_CHECK_ERROR(errorcode);
-	AURA_OPENCL_SAFE_CALL(clBuildProgram(m, 1, &d.get_backend_device(),
-				build_options, NULL, NULL));
-	print_module_build_log(m, d);
-	return m;
-}
+module create_module_from_file(const char * filename, device & d,
+		const char * build_options);
 
+void print_module_build_log(const module & m, const device & d);
+
+
+class module
+{
+
+private:
+	BOOST_MOVABLE_BUT_NOT_COPYABLE(module)
+
+
+public:
+	inline explicit module() : device_(nullptr), program_(nullptr) {}
+
+	inline explicit module(const char * str, device & d,
+			 const char * build_options=NULL)
+			: device_(&d)
+	{
+		int errorcode = 0;
+		std::size_t len = strlen(str);
+		program_ = clCreateProgramWithSource(get_backend_context(*device_), 1,
+						     &str, &len, &errorcode);
+		AURA_OPENCL_CHECK_ERROR(errorcode);
+		AURA_OPENCL_SAFE_CALL(clBuildProgram(program_, 1, &(get_backend_device(*device_)),
+						     build_options, NULL, NULL));
+		print_module_build_log(*this, *device_);
+	}
+
+	/**
+	 * destoy module
+	 */
+	inline ~module()
+	{
+		finalize();
+	}
+
+	/**
+	* move constructor, move module here, invalidate other
+	*
+	* @param m module to move here
+	*/
+	module(BOOST_RV_REF(module) m) :
+		device_(m.device_),
+		program_(m.program_),
+		kernels_(std::move(m.kernels_))
+	{
+		m.device_ = nullptr;
+		m.program_ = nullptr;
+		m.kernels_.clear();
+	}
+
+	/**
+	* move assignment, move device information here, invalidate other
+	*
+	* @param d device to move here
+	*/
+	module& operator=(BOOST_RV_REF(module) m)
+	{
+		finalize();
+		device_ = m.device_;
+		program_ = m.program_;
+		kernels_ = std::move(m.kernels_);
+
+		m.device_ = nullptr;
+		m.program_ = nullptr;
+		m.kernels_.clear();
+		return *this;
+	}
+
+
+	inline kernel & get_kernel(const char * kernel_name)
+	{
+		auto it = kernels_.find(kernel_name);
+		if (kernels_.end() == it) {
+			int errorcode = 0;
+			kernel k = clCreateKernel(program_, kernel_name, &errorcode);
+			AURA_OPENCL_CHECK_ERROR(errorcode);
+			auto it2 = kernels_.insert(
+				std::make_pair(kernel_name, k));
+			it = it2.first;
+		}
+		return it->second;
+	}
+
+
+
+
+	// access the device
+	const device& get_device() const
+	{
+		return *device_;
+	}
+	device& get_device()
+	{
+		return *device_;
+	}
+
+	// access the program
+	const cl_program get_backend_module() const
+	{
+		return program_;
+	}
+	cl_program get_backend_module()
+	{
+		return program_;
+	}
+
+
+private:
+	/// finalize object (called from dtor and move assign)
+	void finalize()
+	{
+		for (auto& it : kernels_) {
+			clReleaseKernel(it.second);
+		}
+		if (nullptr != program_) {
+			clReleaseProgram(program_);
+		}
+	}
+
+private:
+	device * device_;
+	cl_program program_;
+	std::unordered_map<std::string, kernel> kernels_;
+};
 
 /**
  * @brief build a kernel module from a source file 
@@ -58,8 +168,38 @@ inline module create_module_from_file(const char * filename, device & d,
 	in.seekg(0, std::ios::beg);
 	in.read(&data[0], data.size());
 	in.close();
-	return create_module_from_string(data.c_str(), d, build_options);
+	return std::move(module(data.c_str(), d, build_options));
 }
+
+
+/**
+ * @brief print the module build log
+ *
+ * @param m the module that is built
+ * @param d the device the module is built for
+ */
+
+inline void print_module_build_log(const module & m, const device & d) {
+  // from http://stackoverflow.com/a/9467325/244786
+  // Determine the size of the log
+  std::size_t log_size;
+  clGetProgramBuildInfo(m.get_backend_module(), get_backend_device(d),
+    CL_PROGRAM_BUILD_LOG, 0, NULL, &log_size);
+
+  // Allocate memory for the log
+  char *log = (char *) malloc(log_size);
+
+  // Get the log
+  clGetProgramBuildInfo(m.get_backend_module(), get_backend_device(d), CL_PROGRAM_BUILD_LOG,
+    log_size, log, NULL);
+
+  // Print the log
+  if (strncmp("\n\0", log, 2) != 0) {
+	printf("%s\n", log);
+  }
+  free(log);
+}
+
 
 } // opencl
 } // backend_detail

--- a/include/boost/aura/math/add.hpp
+++ b/include/boost/aura/math/add.hpp
@@ -42,8 +42,7 @@ void add(DeviceRangeType& input_range1,
 	backend::kernel k = aura::traits::get_device(input_range1).
 		load_from_string(std::get<0>(kernel_data),
 				std::get<1>(kernel_data),
-				AURA_BACKEND_COMPILE_FLAGS, true);
-
+				AURA_BACKEND_COMPILE_FLAGS);
 	invoke(k, aura::traits::bounds(input_range1), 
 			args(aura::traits::begin_raw(input_range1), 
 				aura::traits::begin_raw(input_range2),

--- a/test/backend/kernel.cpp
+++ b/test/backend/kernel.cpp
@@ -20,7 +20,7 @@ BOOST_AUTO_TEST_CASE(basic)
 	int num = device_get_count();
 	BOOST_REQUIRE(0 < num);
 	device d(0); 
-	module m = create_module_from_file(kernel_file, d, 
+	module m = create_module_from_file(kernel_file, d,
 	AURA_BACKEND_COMPILE_FLAGS);
 	kernel k = create_kernel(m, "donothing");
 	(void)k; 
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(invoke_simple)
 	std::vector<float> a1(xdim*ydim, 41.);
 	std::vector<float> a2(xdim*ydim);
 
-	module mod = create_module_from_file(kernel_file, d, 
+	module mod = create_module_from_file(kernel_file, d,
 	AURA_BACKEND_COMPILE_FLAGS);
 	print_module_build_log(mod, d);
 	kernel k = create_kernel(mod, "simple_add"); 
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(invoke_donothing)
 	std::size_t xdim = 16;
 	std::size_t ydim = 16;
 
-	module mod = create_module_from_file(kernel_file, d, 
+	module mod = create_module_from_file(kernel_file, d,
 	AURA_BACKEND_COMPILE_FLAGS);
 
 	kernel k = create_kernel(mod, "donothing"); 
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(invoke_shared)
 	std::vector<float> a1(xdim*ydim, 0.);
 	std::vector<float> a2(xdim*ydim);
 
-	module mod = create_module_from_file(kernel_file, d, 
+	module mod = create_module_from_file(kernel_file, d,
 	AURA_BACKEND_COMPILE_FLAGS);
 	print_module_build_log(mod, d);
 	kernel k = create_kernel(mod, "simple_shared"); 
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(invoke_atomic)
 	std::vector<float> a1(xdim*ydim, 0.);
 	std::vector<float> a2(xdim*ydim);
 
-	module mod = create_module_from_file(kernel_file, d, 
+	module mod = create_module_from_file(kernel_file, d,
 	AURA_BACKEND_COMPILE_FLAGS);
 	print_module_build_log(mod, d);
 	kernel k = create_kernel(mod, "simple_atomic"); 


### PR DESCRIPTION
Soo,

apparently mxnlinv has higher priority than I thought, and therefore this memory leak (explained in #5 ) does as well.

Here is a first version of the module type (github doesn't like my force-pushed history, that's why I have to make a new pull request).

As far as I can tell, pretty much none of the previous (external) usage of the module has changed. 

Some ugly things in this: Both the module and the device want access to each other's internal implementations. This is, unfortunately, not possible using two files (or at least I couldn't find a way to make it work). So I had to create two access functions to the device, that are not member functions (`const cl_device_id & get_backend_device(const device & d)` and `const cl_context & get_backend_context(const device & d)`). 

One way of achieving this is, I think, putting the module class definition inside of the device class. This would make sense, because the modules really are owned by the device and they live on the device (as evidenced by the `std::unordered_map` used to hold modules). This way, access to modules would necessarily go through the device.
This would break the existing usage of the module type, though. For example, `test/test.backend.kernel` uses modules on their own, which would not be possible anymore.

So, you need to decide which way you want it. I'll implement the same thing for the CUDA side once I know which way to go (and probably a test for multiple kernels in a single module).
And one more thing: the kernels really are pretty low level things, and they get cleaned up properly now. Do you think it still makes sense to give them their own class, too, and changing them from being `typedef`s?

Greetings,
Christian
